### PR TITLE
chore(technical): Make contributing more xplat friendly

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.github/workflows/test-all-versions.yml
+++ b/.github/workflows/test-all-versions.yml
@@ -22,7 +22,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
     steps:
       - uses: actions/checkout@v5
 
@@ -47,7 +52,7 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: package-dist
+          name: package-dist-${{ matrix.os }}
           path: |
             console-table-printer-*.tgz
             test/githubActionsTest/package-test.js
@@ -55,10 +60,11 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x, 20.x, 22.x]
+        os: [ubuntu-latest, windows-latest]
       fail-fast: false
 
     steps:
@@ -72,9 +78,10 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v5
         with:
-          name: package-dist
+          name: package-dist-${{ matrix.os }}
 
       - name: Test package
+        shell: bash
         run: |
           mkdir test-pkg && cd test-pkg
           mv ../console-table-printer-*.tgz ./

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-  "endOfLine": "lf",
+  "endOfLine": "auto",
   "semi": true,
   "singleQuote": true,
   "tabWidth": 2,

--- a/test/infrastructuralTest/jest-discovery.test.ts
+++ b/test/infrastructuralTest/jest-discovery.test.ts
@@ -19,7 +19,8 @@ describe('Jest Test Discovery', () => {
     .filter((line) => line.endsWith('.test.ts') || line.endsWith('.test.js'))
     .map((line) => line.trim())
     .filter(Boolean)
-    .map((file) => path.relative(process.cwd(), file)); // Convert to relative paths
+    // Convert to relative paths, normalizing path separators for cross-platform compatibility
+    .map((file) => path.relative(process.cwd(), file).replace(/\\/g, '/'));
 
   // Expected test files (using relative paths)
   const expectedFiles: string[] = [


### PR DESCRIPTION
## 👀What is this pr about?

Make contributing to this lib a little bit easier when working from a Windows OS

## 🚀 Changes

### Updated

- .gitattributes will take care of ensuring only `lf` are staged
- Switch .prettierrc `endOfLine` to `auto` to silence the eslint warnings on Windows
- Teach infrastructural tests to also pass on Windows
- Update PullRequest workflow to also run on a Windows agent